### PR TITLE
updating again- lots of changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,8 +3,6 @@
 Simple Streamlit front-end to display announcements from MongoDB.
 
 Shows title, school, date, URL, and source base URL for each announcement.
-OPTIMIZED VERSION with fast pagination using MongoDB skip/limit.
-UPDATED: Simplified health checks and automated daily Slack notifications for failed scrapers.
 """
 
 import os
@@ -16,6 +14,7 @@ import pandas as pd
 import io
 import pytz
 from tzlocal import get_localzone
+import json
 
 
 # Load environment variables from .env file
@@ -49,25 +48,63 @@ def utc_to_local(utc_dt):
 # Connect to MongoDB with connection pooling
 @st.cache_resource
 def get_db():
-    client = MongoClient(MONGO_URI, maxPoolSize=10)
+    client = MongoClient(MONGO_URI, maxPoolSize=50, minPoolSize=5, maxIdleTimeMS=30000)
     return client[DB_NAME]
 
 @st.cache_data(ttl=300)  # Cache for 5 minutes
 def get_filtered_count(mongo_uri, db_name, query_str):
     """Get count of documents matching query - cached for performance"""
-    import json
     client = MongoClient(mongo_uri)
     db = client[db_name]
     query = json.loads(query_str)
     return db.articles.count_documents(query)
 
-@st.cache_data(ttl=60)  # Cache for 1 minute  
-def get_schools_list(mongo_uri, db_name):
-    """Get list of schools - cached for performance"""
+@st.cache_data(ttl=300)  # Increased cache time for better performance
+def get_organizations_data(mongo_uri, db_name):
+    """Get all organizations data - cached for performance"""
     client = MongoClient(mongo_uri)
     db = client[db_name]
-    schools_cursor = db.orgs.find({}, {"_id": 0, "name": 1})
-    return [{"name": org.get("name")} for org in schools_cursor]
+    orgs_cursor = db.orgs.find({}, {"name": 1, "color": 1, "scrapers": 1})
+    return list(orgs_cursor)
+
+@st.cache_data(ttl=300)  # Cache for 5 minutes
+def get_scraper_mapping(organizations_data):
+    """Create mapping from scraper path to scraper info - cached"""
+    scraper_mapping = {}
+    scraper_types = set()
+    
+    for org in organizations_data:
+        org_name = org.get("name", "Unknown School")
+        org_color = org.get("color", "#000000")
+        scrapers = org.get("scrapers", [])
+        
+        for scraper in scrapers:
+            path = scraper.get("path", "")
+            name = scraper.get("name", "")
+            
+            if path:
+                scraper_mapping[path] = {
+                    "name": name,
+                    "org_name": org_name,
+                    "org_color": org_color
+                }
+            
+            if name:
+                scraper_types.add(name)
+    
+    return scraper_mapping, sorted(list(scraper_types))
+
+def get_scraper_paths_by_type(organizations_data, scraper_type):
+    """Get all scraper paths that match a specific type name"""
+    matching_paths = []
+    for org in organizations_data:
+        scrapers = org.get("scrapers", [])
+        for scraper in scrapers:
+            if scraper.get("name") == scraper_type:
+                path = scraper.get("path")
+                if path:
+                    matching_paths.append(path)
+    return matching_paths
 
 def send_slack_notification(failed_scrapers, is_daily_report=False):
     """Send Slack notification for completely failed scrapers"""
@@ -109,7 +146,7 @@ def send_slack_notification(failed_scrapers, is_daily_report=False):
         print(f"❌ Error sending Slack notification: {e}")
         return False
 
-def check_and_send_daily_report(db):
+def check_and_send_daily_report(db, organizations_data):
     """Check for failed scrapers and send daily report if needed"""
     # Check if we've already sent a report today
     today = datetime.now(timezone.utc).date()
@@ -130,13 +167,12 @@ def check_and_send_daily_report(db):
     except Exception as e:
         print(f"Error checking last report date: {e}")
     
-    # Get failed scrapers using same logic as display function
-    schools = list(db.orgs.find({"scrapers": {"$exists": True}}, {"name": 1, "scrapers": 1}))
+    # Get failed scrapers using optimized data
     failed_scrapers = []
     
-    for school in schools:
-        school_name = school.get("name", "Unknown School")
-        scrapers = school.get("scrapers", [])
+    for org in organizations_data:
+        school_name = org.get("name", "Unknown School")
+        scrapers = org.get("scrapers", [])
         
         for scraper in scrapers:
             last_run = scraper.get("last_run")
@@ -216,8 +252,12 @@ def display_announcements(db):
     """Display the announcements view with optimized pagination."""
     st.markdown('⚠️ Please note that this is an unedited **first draft** proof-of-concept. Classifications **WILL BE** inaccurate. ⚠️', unsafe_allow_html=True)
 
-    # Use cached schools list
-    schools = get_schools_list(MONGO_URI, DB_NAME)
+    # Get cached organizations data once
+    organizations_data = get_organizations_data(MONGO_URI, DB_NAME)
+    scraper_mapping, scraper_types = get_scraper_mapping(organizations_data)
+    
+    # Extract school names from organizations data
+    school_names = sorted([org["name"] for org in organizations_data])
 
     st.markdown('>_Check any box to filter for items identified by our LLM as related to that category.<br/>Hover on each question mark for more information about the criteria._', unsafe_allow_html=True)
 
@@ -262,16 +302,30 @@ def display_announcements(db):
     # Add a text search bar for content search
     search_term = st.text_input("🔍 Search announcement content", value="", key="search_term", help="Enter keywords to search announcement content (case-insensitive)")
 
-    # Create a dropdown for school selection with alphabetically sorted options
-    school_names = [school["name"] for school in schools]
-    school_names.sort()  # Sort school names alphabetically
-    school_options = ["All"] + school_names
-    selected_school = st.selectbox("Filter by School", school_options)
+    # Create two columns for filters
+    filter_col1, filter_col2 = st.columns(2)
+    
+    with filter_col1:
+        # Create a dropdown for school selection with alphabetically sorted options
+        school_options = ["All"] + school_names
+        selected_school = st.selectbox("Filter by School", school_options)
+    
+    with filter_col2:
+        # Create a dropdown for scraper type selection
+        scraper_type_options = ["All"] + scraper_types
+        selected_scraper_type = st.selectbox("Filter by Announcement Type", scraper_type_options, help="Filter by the type of announcements (e.g., provost, president, etc.)")
 
     # Build the query based on the selected school
     query = {}
     if selected_school != "All":
         query["org"] = selected_school
+
+    # Add scraper type filter to query
+    if selected_scraper_type != "All":
+        # Get all scraper paths that match the selected type
+        matching_paths = get_scraper_paths_by_type(organizations_data, selected_scraper_type)
+        if matching_paths:
+            query["scraper"] = {"$in": matching_paths}
 
     # Add filters based on selected categories
     filter_conditions = []
@@ -308,7 +362,6 @@ def display_announcements(db):
         query["content"] = {"$regex": search_term, "$options": "i"}
 
     # === CRITICAL OPTIMIZATION: Use cached count query ===
-    import json
     query_str = json.dumps(query, default=str)  # Convert datetime to string for caching
     num_announcements = get_filtered_count(MONGO_URI, DB_NAME, query_str)
 
@@ -323,7 +376,7 @@ def display_announcements(db):
         st.session_state["ann_page"] = 0
     
     # Reset to page 0 when filters change
-    filter_state_key = f"{selected_school}_{show_govt_related}_{show_lawsuit_related}_{show_funding_related}_{show_protest_related}_{show_layoff_related}_{show_president_related}_{show_provost_related}_{show_faculty_related}_{show_trustees_related}_{show_trump_related}_{search_term}"
+    filter_state_key = f"{selected_school}_{selected_scraper_type}_{show_govt_related}_{show_lawsuit_related}_{show_funding_related}_{show_protest_related}_{show_layoff_related}_{show_president_related}_{show_provost_related}_{show_faculty_related}_{show_trustees_related}_{show_trump_related}_{search_term}"
     if "last_filter_state" not in st.session_state:
         st.session_state["last_filter_state"] = filter_state_key
     elif st.session_state["last_filter_state"] != filter_state_key:
@@ -343,7 +396,7 @@ def display_announcements(db):
                 with st.spinner("Generating CSV file..."):
                     all_cursor = db.articles.find(query, {"_id": 0}).sort("date", -1)
                     all_announcements = list(all_cursor)
-                    csv = convert_to_csv(all_announcements, db)
+                    csv = convert_to_csv(all_announcements, scraper_mapping)
                     st.download_button(
                         label="📥 Download CSV",
                         data=csv,
@@ -380,23 +433,26 @@ def display_announcements(db):
         else:
             date_str = str(date_value)
 
-        # Get school name and color
+        # Get school info and scraper type using cached mapping
+        scraper_path = ann.get("scraper", "")
         school_name = ann.get("org", "Unknown School")
-        school_color = "#000000"  # Default to black if no color is found
-        school_doc = db.orgs.find_one({"name": school_name}, {"color": 1})
-        if school_doc and school_doc.get("color"):
-            school_color = school_doc["color"]
+        school_color = "#000000"  # Default
+        scraper_type_display = "Unknown Type"
+        
+        if scraper_path in scraper_mapping:
+            scraper_info = scraper_mapping[scraper_path]
+            scraper_type_display = scraper_info["name"]
+            school_color = scraper_info["org_color"]
 
         # Announcement URL
         url = ann.get("url", "")
-        # Source base URL (if runner annotated it)
-        base_url = ann.get("base_url", "")
 
         st.subheader(title)
         content = ann.get("content", "")
         announcement_html = f"""
         <p style="margin-bottom: 0.5em;">
             <strong>School:</strong> <span style="background-color:{school_color}; padding:2px 4px; border-radius:4px; color:#ffffff;">{school_name}</span><br>
+            <strong>Type:</strong> {scraper_type_display}<br>
             <strong>Date:</strong> {date_str}<br>
             <strong>Content Scraped:</strong> {'✅' if content else '👎'}<br>
             <strong>Announcement URL:</strong><br/> <a href="{url}">{url}</a>
@@ -490,17 +546,17 @@ def display_announcements(db):
     with col_prev:
         if st.button("⬅️ Prev", key="ann_prev", disabled=st.session_state["ann_page"] == 0):
             st.session_state["ann_page"] = max(st.session_state["ann_page"] - 1, 0)
-            st.rerun()  # Use st.rerun() instead of st.stop()
+            st.rerun()
     with col_page:
         st.markdown(f"<div style='text-align:center;'>Page <b>{st.session_state['ann_page']+1}</b> of <b>{total_pages}</b></div>", unsafe_allow_html=True)
     with col_next:
         if st.button("Next ➡️", key="ann_next", disabled=st.session_state["ann_page"] >= total_pages - 1):
             st.session_state["ann_page"] = min(st.session_state["ann_page"] + 1, total_pages - 1)
-            st.rerun()  # Use st.rerun() instead of st.stop()
+            st.rerun()
 
 
-def convert_to_csv(announcements, db):
-    """Convert announcements data to CSV format, excluding content column."""
+def convert_to_csv(announcements, scraper_mapping):
+    """Convert announcements data to CSV format, using cached scraper mapping."""
     # Create a list to store processed announcements
     processed_data = []
     
@@ -511,8 +567,15 @@ def convert_to_csv(announcements, db):
             "school": ann.get("org", ""),
             "date": ann.get("date"),
             "url": ann.get("url", ""),
-            # "base_url": ann.get("base_url", "")
         }
+        
+        # Add scraper type information to CSV using cached mapping
+        scraper_path = ann.get("scraper", "")
+        scraper_type = "Unknown Type"
+        if scraper_path in scraper_mapping:
+            scraper_type = scraper_mapping[scraper_path]["name"]
+        
+        processed_ann["announcement_type"] = scraper_type
         
         # Add LLM response fields if available
         llm_response = ann.get("llm_response", {})
@@ -548,11 +611,14 @@ def display_scraper_status(db):
     """Display the scraper status tab with SIMPLIFIED health check."""
     st.markdown("### URLs")
     
+    # Get cached organizations data
+    organizations_data = get_organizations_data(MONGO_URI, DB_NAME)
+    
     # === AUTO-CHECK FOR DAILY REPORT ===
     # Check and potentially send daily report when this tab is loaded
     if SLACK_WEBHOOK_URL:
         try:
-            sent, message = check_and_send_daily_report(db)
+            sent, message = check_and_send_daily_report(db, organizations_data)
             if sent and "failed scrapers" in message:
                 st.info(f"📊 {message}")
             elif sent and "healthy" in message:
@@ -560,22 +626,17 @@ def display_scraper_status(db):
         except Exception as e:
             st.warning(f"⚠️ Daily report check failed: {e}")
     
-    # Fetch all schools with scraper information
-    schools = list(db.orgs.find(
-        {"scrapers": {"$exists": True}}, 
-        {"name": 1, "scrapers": 1, "last_run": 1}
-    ).sort("name", 1))
-    
-    if not schools:
+    if not organizations_data:
         st.warning("No scraper information found in the database.")
         return
     
     # Count total scrapers
-    total_scrapers = sum(len(school.get("scrapers", [])) for school in schools)
+    total_scrapers = sum(len(org.get("scrapers", [])) for org in organizations_data)
     
     # Create a list to hold all scrapers data
     all_scrapers_data = []
     health_counts = {"healthy": 0, "unhealthy": 0}
+<<<<<<< Updated upstream
     failed_scrapers = []  # For Slack notifications
     
     # Extract all scrapers from all schools into a flat list with school info
@@ -870,3 +931,6 @@ def display_schools_summary(db):
 
 if __name__ == "__main__":
     main()
+=======
+    failed_scrapers = []  # For
+>>>>>>> Stashed changes


### PR DESCRIPTION
 Havr had a bunch of smaller ideas in mind, 
 
 MongoDB connection pooling
-Increased maxPoolSize from 10 to 50
- Added minPoolSize=5 and maxIdleTimeMS=30000 for better connection management

 Cached data loading strat
- Created get_organizations_data() function that caches all org data for 5 minutes max (can be extended)
- Eliminates multiple database calls for school/scraper info
- New get_scraper_mapping() function creates a lookup table once
- Maps scraper paths to names/colors instantly instead of querying DB for each announcement
- Caches scraper types list to avoid repeated processing

Optimized Display Logic

- Killed individual database lookups for school colors and scraper types in the display loop
- Uses cached mapping instead of db.orgs.find_one() calls for each announcement andd  cached scraper mapping instead of database queries (faster for outputting CSVs)

Enhanced Caching
- Increased cache time for organizations data from 60 seconds to 5 minutes
- Better cache hit rates for frequently accessed data (gave it a little memory)

The big one-Scraper type Filtering! 
- Added "Filter by Announcement Type" dropdown alongside school filter that allows for  filtering by announcement types like "provost announcements", "president announcements", etc.
- Includes announcement type in CSV exports! 

@dmil would love your gut check on this BEFORE merging